### PR TITLE
Remove Rubyforge project declaration from gemspec

### DIFF
--- a/machinist.gemspec
+++ b/machinist.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/notahat/machinist"
   s.summary  = "Fixtures aren't fun. Machinist is."
 
-  s.rubyforge_project = "machinist"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Fixes the Rubygems warning:

> NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
 

